### PR TITLE
Implement compatiblity checks & message endpoint streaming

### DIFF
--- a/pkg/anthropic/message.go
+++ b/pkg/anthropic/message.go
@@ -15,6 +15,10 @@ func (c *Client) Message(req *MessageRequest) (*MessageResponse, error) {
 		return nil, fmt.Errorf("cannot use Message with streaming enabled, use MessageStream instead.")
 	}
 
+	if !req.Model.IsMessageCompatible() {
+		return nil, fmt.Errorf("model %s is not compatible with the message endpoint", req.Model)
+	}
+
 	return c.sendMessageRequest(req)
 }
 
@@ -29,7 +33,7 @@ func (c *Client) MessageStream(req *MessageRequest) (<-chan MessageStreamRespons
 		return events, errCh
 	}
 
-	if !req.Model.IsMessageStreamCompatible() {
+	if !req.Model.IsMessageCompatible() {
 		errCh <- fmt.Errorf("model %s is not compatible with the messagestream endpoint", req.Model)
 		return events, errCh
 	}

--- a/pkg/anthropic/message.go
+++ b/pkg/anthropic/message.go
@@ -1,23 +1,42 @@
 package anthropic
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 )
 
 func (c *Client) Message(req *MessageRequest) (*MessageResponse, error) {
 	if req.Stream {
-		return nil, fmt.Errorf("cannot use Message with streaming enabled, use MessageStream instead (not yet supported)")
+		return nil, fmt.Errorf("cannot use Message with streaming enabled, use MessageStream instead.")
 	}
 
 	return c.sendMessageRequest(req)
 }
 
-// MessageStream (NOT YET SUPPORTED) returns a channel of StreamResponse objects and a channel of errors.
-func (c *Client) MessageStream(req *MessageRequest) (<-chan StreamResponse, <-chan error) {
-	return nil, nil
+func (c *Client) MessageStream(req *MessageRequest) (<-chan MessageStreamResponse, <-chan error) {
+	events := make(chan MessageStreamResponse)
+
+	// make this a buffered channel to allow for the error case below to return
+	errCh := make(chan error, 1)
+
+	if !req.Stream {
+		errCh <- fmt.Errorf("cannot use MessageStream with a non-streaming request, use Message instead")
+		return events, errCh
+	}
+
+	if !req.Model.IsMessageStreamCompatible() {
+		errCh <- fmt.Errorf("model %s is not compatible with the messagestream endpoint", req.Model)
+		return events, errCh
+	}
+
+	go c.handleMessageStreaming(events, errCh, req)
+
+	return events, errCh
 }
 
 func (c *Client) sendMessageRequest(req *MessageRequest) (*MessageResponse, error) {
@@ -52,4 +71,72 @@ func (c *Client) sendMessageRequest(req *MessageRequest) (*MessageResponse, erro
 	}
 
 	return &messageResponse, nil
+}
+
+func (c *Client) handleMessageStreaming(events chan MessageStreamResponse, errCh chan error, req *MessageRequest) {
+	defer close(events)
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		errCh <- fmt.Errorf("error marshalling message request: %w", err)
+		return
+	}
+
+	request, err := http.NewRequest("POST", fmt.Sprintf("%s/v1/messages", c.baseURL), bytes.NewBuffer(data))
+	if err != nil {
+		errCh <- fmt.Errorf("error creating new request: %w", err)
+		return
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Api-Key", c.apiKey)
+	request.Header.Set("Accept", "text/event-stream")
+
+	response, err := c.doRequest(request)
+	if err != nil {
+		errCh <- fmt.Errorf("error sending message request: %w", err)
+		return
+	}
+	defer response.Body.Close()
+
+	err = c.processMessageSseStream(response.Body, events)
+	if err != nil {
+		errCh <- err
+	}
+}
+
+func (c *Client) processMessageSseStream(reader io.Reader, events chan MessageStreamResponse) error {
+	scanner := bufio.NewScanner(reader)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.HasPrefix(line, "data:") {
+			data := strings.TrimSpace(line[5:])
+
+			event := &MessageEvent{}
+			err := json.Unmarshal([]byte(data), event)
+			if err != nil {
+				return fmt.Errorf("error decoding event data: %w", err)
+			}
+
+			msg, err := parseMessageEvent(event.Type, data)
+
+			if err != nil {
+				if _, ok := err.(UnsupportedEventType); ok {
+					// ignore unsupported event types
+				} else {
+					return fmt.Errorf("error processing message stream: %v", err)
+				}
+			}
+
+			events <- msg
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading from stream: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/anthropic/message_event.go
+++ b/pkg/anthropic/message_event.go
@@ -133,7 +133,10 @@ func parseMessageEvent(eventType, event string) (MessageStreamResponse, error) {
 		messageStreamResponse.Type = messageStopEvent.Type
 	case "error":
 		messageErrorEvent := &MessageErrorEvent{}
-		_ = json.Unmarshal([]byte(event), &messageErrorEvent)
+		err = json.Unmarshal([]byte(event), &messageErrorEvent)
+		if err != nil {
+			return messageStreamResponse, err
+		}
 
 		// error received on stream
 		return messageStreamResponse, fmt.Errorf(

--- a/pkg/anthropic/message_event.go
+++ b/pkg/anthropic/message_event.go
@@ -1,0 +1,149 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type MessageEvent struct {
+	Type string `json:"type"`
+}
+
+type MessageStartEvent struct {
+	MessageEvent
+	Message struct {
+		ID           string        `json:"id"`
+		Type         string        `json:"type"`
+		Role         string        `json:"role"`
+		Content      []interface{} `json:"content"`
+		Model        string        `json:"model"`
+		StopReason   string        `json:"stop_reason"`
+		StopSequence string        `json:"stop_sequence"`
+		Usage        struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+type ContentBlockStartEvent struct {
+	MessageEvent
+	Index        int `json:"index"`
+	ContentBlock struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content_block"`
+}
+
+type PingEvent struct {
+	MessageEvent
+}
+
+type ContentBlockDeltaEvent struct {
+	MessageEvent
+	Index int `json:"index"`
+	Delta struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"delta"`
+}
+
+type ContentBlockStopEvent struct {
+	MessageEvent
+	Index int `json:"index"`
+}
+
+type MessageDeltaEvent struct {
+	MessageEvent
+	Delta struct {
+		StopReason   string `json:"stop_reason"`
+		StopSequence string `json:"stop_sequence"`
+		Usage        struct {
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	} `json:"delta"`
+}
+
+type MessageStopEvent struct {
+	MessageEvent
+}
+
+type MessageErrorEvent struct {
+	MessageEvent
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type UnsupportedEventType struct {
+	Msg  string
+	Code int
+}
+
+func (e UnsupportedEventType) Error() string {
+	return fmt.Sprintf("%s", e.Msg)
+}
+
+func parseMessageEvent(eventType, event string) (MessageStreamResponse, error) {
+	messageStreamResponse := MessageStreamResponse{}
+	var err error
+
+	switch eventType {
+	case "message_start":
+		messageStartEvent := &MessageStartEvent{}
+		err = json.Unmarshal([]byte(event), &messageStartEvent)
+
+		messageStreamResponse.Type = messageStartEvent.Type
+		messageStreamResponse.Usage = messageStartEvent.Message.Usage
+	case "content_block_start":
+		contentBlockEvent := &ContentBlockStartEvent{}
+		err = json.Unmarshal([]byte(event), &contentBlockEvent)
+
+		messageStreamResponse.Type = contentBlockEvent.Type
+	case "ping":
+		pingEvent := &PingEvent{}
+		err = json.Unmarshal([]byte(event), &pingEvent)
+
+		messageStreamResponse.Type = pingEvent.Type
+	case "content_block_delta":
+		contentBlockEvent := &ContentBlockDeltaEvent{}
+		err = json.Unmarshal([]byte(event), &contentBlockEvent)
+
+		messageStreamResponse.Type = contentBlockEvent.Type
+		messageStreamResponse.Delta.Type = contentBlockEvent.Delta.Type
+		messageStreamResponse.Delta.Text = contentBlockEvent.Delta.Text
+	case "content_block_stop":
+		contentBlockStopEvent := &ContentBlockStopEvent{}
+		err = json.Unmarshal([]byte(event), &contentBlockStopEvent)
+
+		messageStreamResponse.Type = contentBlockStopEvent.Type
+	case "message_delta":
+		messageDeltaEvent := &MessageDeltaEvent{}
+		err = json.Unmarshal([]byte(event), &messageDeltaEvent)
+
+		messageStreamResponse.Type = messageDeltaEvent.Type
+		messageStreamResponse.Delta.StopReason = messageDeltaEvent.Delta.StopReason
+		messageStreamResponse.Delta.StopSequence = messageDeltaEvent.Delta.StopSequence
+		messageStreamResponse.Usage.OutputTokens = messageDeltaEvent.Delta.Usage.OutputTokens
+	case "message_stop":
+		messageStopEvent := &MessageStopEvent{}
+		err = json.Unmarshal([]byte(event), &messageStopEvent)
+
+		messageStreamResponse.Type = messageStopEvent.Type
+	case "error":
+		messageErrorEvent := &MessageErrorEvent{}
+		_ = json.Unmarshal([]byte(event), &messageErrorEvent)
+
+		// error received on stream
+		return messageStreamResponse, fmt.Errorf(
+			"error type: %s, message: %s",
+			messageErrorEvent.Error.Type,
+			messageErrorEvent.Error.Message,
+		)
+	default:
+		err = UnsupportedEventType{Msg: "unknown event type"}
+	}
+
+	return messageStreamResponse, err
+}

--- a/pkg/anthropic/message_test.go
+++ b/pkg/anthropic/message_test.go
@@ -2,8 +2,10 @@ package anthropic
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -77,7 +79,39 @@ func TestMessageErrorHandling(t *testing.T) {
 	}
 }
 
-func TestMessageStreamNotSupported(t *testing.T) {
+func TestMessageStreamNoStreamFlag(t *testing.T) {
+	// Create client
+	client, err := NewClient("fake-api-key")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Prepare a message request without streaming
+	request := &MessageRequest{
+		Model:    ClaudeV2,
+		Messages: []MessagePartRequest{{Role: "user", Content: "Hello"}},
+	}
+
+	// Call the MessageStream method expecting an error
+	_, errCh := client.MessageStream(request)
+
+	err = <-errCh
+	if err == nil {
+		t.Fatal("Expected an error for streaming without a stream request")
+	}
+
+	expErr := "cannot use MessageStream with a non-streaming request, use Message instead"
+
+	if err.Error() != expErr {
+		t.Fatalf(
+			"Expected error %s, got %s",
+			expErr,
+			err.Error(),
+		)
+	}
+}
+
+func TestMessageStreamIncompatibleModel(t *testing.T) {
 	// Create client
 	client, err := NewClient("fake-api-key")
 	if err != nil {
@@ -86,14 +120,170 @@ func TestMessageStreamNotSupported(t *testing.T) {
 
 	// Prepare a message request with streaming set to true
 	request := &MessageRequest{
-		Model:    ClaudeV2_1,
+		Model:    ClaudeV2,
 		Messages: []MessagePartRequest{{Role: "user", Content: "Hello"}},
 		Stream:   true,
 	}
 
-	// Call the Message method expecting an error
-	_, err = client.Message(request)
+	// Call the MessageStream method expecting an error
+	_, errCh := client.MessageStream(request)
+
+	err = <-errCh
 	if err == nil {
 		t.Fatal("Expected an error for streaming not supported, got none")
+	}
+
+	expErr := fmt.Sprintf("model %s is not compatible with the messagestream endpoint", request.Model)
+
+	if err.Error() != expErr {
+		t.Fatalf(
+			"Expected error %s, got %s",
+			expErr,
+			err.Error(),
+		)
+	}
+}
+
+func TestMessageStreamSuccess(t *testing.T) {
+	// Create a test server to mock the Anthropics API
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+
+		output := []byte{}
+		output = append(output, []byte("event: message_start\n")...)
+		output = append(output, []byte("data: {\"type\": \"message_start\", \"message\": {\"id\": \"msg_1nZdL29xx5MUA1yADyHTEsnR8uuvGzszyY\", \"type\": \"message\", \"role\": \"assistant\", \"content\": [], \"model\": \"claude-3-opus-20240229\", \"stop_reason\": null, \"stop_sequence\": null, \"usage\": {\"input_tokens\": 25, \"output_tokens\": 1}}}\n\n")...)
+		output = append(output, []byte("event: content_block_start\n")...)
+		output = append(output, []byte("data: {\"type\": \"content_block_start\", \"index\":0, \"content_block\": {\"type\": \"text\", \"text\": \"\"}}\n\n")...)
+		output = append(output, []byte("event: ping\n")...)
+		output = append(output, []byte("data: {\"type\": \"ping\"}\n\n")...)
+		output = append(output, []byte("event: not_really_anything_just_testing_unknown_event\n")...)
+		output = append(output, []byte("data: {\"type\": \"not_really_anything_just_testing_unknown_event\"}\n\n")...)
+		output = append(output, []byte("event: content_block_delta\n")...)
+		output = append(output, []byte("data: {\"type\": \"content_block_delta\", \"index\": 0, \"delta\": {\"type\": \"text_delta\", \"text\": \"hello there, \"}}\n\n")...)
+		output = append(output, []byte("event: content_block_delta\n")...)
+		output = append(output, []byte("data: {\"type\": \"content_block_delta\", \"index\": 0, \"delta\": {\"type\": \"text_delta\", \"text\": \"general kenobi\"}}\n\n")...)
+		output = append(output, []byte("event: content_block_stop\n")...)
+		output = append(output, []byte("data: {\"type\": \"content_block_stop\", \"index\": 0}\n\n")...)
+		output = append(output, []byte("event: message_delta\n")...)
+		output = append(output, []byte("data: {\"type\": \"message_delta\", \"delta\": {\"stop_reason\": \"end_turn\", \"stop_sequence\":null, \"usage\":{\"output_tokens\": 15}}}\n\n")...)
+		output = append(output, []byte("event: message_stop\n")...)
+		output = append(output, []byte("data: {\"type\": \"message_stop\"}\n\n")...)
+		w.Write(output)
+	}))
+	defer testServer.Close()
+
+	// Create a new client with the test server's URL
+	client, err := NewClient("fake-api-key")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	client.baseURL = testServer.URL // Override baseURL to point to the test server
+
+	// Prepare a message request
+	request := &MessageRequest{
+		Model:    Claude3Opus,
+		Messages: []MessagePartRequest{{Role: "user", Content: "Hello"}},
+		Stream:   true,
+	}
+
+	// Call the Complete method
+	rCh, errCh := client.MessageStream(request)
+	chunk := MessageStreamResponse{}
+	final := strings.Builder{}
+	inputTokens := 0
+	outputTokens := 0
+
+	for {
+		select {
+		case chunk = <-rCh:
+			final.WriteString(chunk.Delta.Text)
+			if chunk.Type == "message_start" {
+				inputTokens = chunk.Usage.InputTokens
+			} else if chunk.Type == "message_delta" {
+				outputTokens = chunk.Usage.OutputTokens
+			}
+		case err := <-errCh:
+			t.Fatalf("Unexpected error: %s", err.Error())
+		}
+		if chunk.Type == "message_stop" {
+			break
+		}
+	}
+
+	// Check the response
+	expectedResult := "hello there, general kenobi"
+	if final.String() != expectedResult {
+		t.Fatalf("Expected result %s, got %s", expectedResult, final.String())
+	}
+
+	// Check the usage
+	if inputTokens != 25 {
+		t.Fatalf("Expected input tokens %d, got %d", 25, inputTokens)
+	}
+
+	if outputTokens != 15 {
+		t.Fatalf("Expected output tokens %d, got %d", 15, outputTokens)
+	}
+}
+
+func TestMessageStreamErrorInStream(t *testing.T) {
+	// Create a test server to mock the Anthropics API
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+
+		output := []byte{}
+		output = append(output, []byte("event: message_start\n")...)
+		output = append(output, []byte("data: {\"type\": \"message_start\", \"message\": {\"id\": \"msg_1nZdL29xx5MUA1yADyHTEsnR8uuvGzszyY\", \"type\": \"message\", \"role\": \"assistant\", \"content\": [], \"model\": \"claude-3-opus-20240229\", \"stop_reason\": null, \"stop_sequence\": null, \"usage\": {\"input_tokens\": 25, \"output_tokens\": 1}}}\n\n")...)
+		output = append(output, []byte("event: content_block_start\n")...)
+		output = append(output, []byte("data: {\"type\": \"content_block_start\", \"index\":0, \"content_block\": {\"type\": \"text\", \"text\": \"\"}}\n\n")...)
+		output = append(output, []byte("event: error\n")...)
+		output = append(output, []byte("data: {\"type\": \"error\", \"error\": {\"type\": \"overload_error\", \"message\": \"Overloaded\"}}\n\n")...)
+		w.Write(output)
+	}))
+	defer testServer.Close()
+
+	// Create a new client with the test server's URL
+	client, err := NewClient("fake-api-key")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	client.baseURL = testServer.URL // Override baseURL to point to the test server
+
+	// Prepare a message request
+	request := &MessageRequest{
+		Model:    Claude3Opus,
+		Messages: []MessagePartRequest{{Role: "user", Content: "Hello"}},
+		Stream:   true,
+	}
+
+	// Call the Complete method
+	rCh, errCh := client.MessageStream(request)
+	var chunk MessageStreamResponse
+	final := strings.Builder{}
+	done := false
+
+	for {
+		select {
+		case chunk = <-rCh:
+			final.WriteString(chunk.Delta.Text)
+		case err = <-errCh:
+			done = true
+			break
+		}
+		if chunk.Type == "message_stop" || done {
+			break
+		}
+	}
+
+	// Check the response is empty
+	expectedResult := ""
+	if final.String() != expectedResult {
+		t.Fatalf("Expected result %s, got %s", expectedResult, final.String())
+	}
+
+	// Check the error
+	expectedError := "error processing message stream: error type: overload_error, message: Overloaded"
+	if expectedError != err.Error() {
+		t.Errorf("Expected error '%s', got '%s'", expectedError, err.Error())
 	}
 }

--- a/pkg/anthropic/message_test.go
+++ b/pkg/anthropic/message_test.go
@@ -21,6 +21,10 @@ func TestMessage(t *testing.T) {
 				Type: "text",
 				Text: "Test message",
 			}},
+			Usage: MessageUsage{
+				InputTokens:  10,
+				OutputTokens: 5,
+			},
 		}
 		json.NewEncoder(w).Encode(resp)
 	}))
@@ -76,6 +80,37 @@ func TestMessageErrorHandling(t *testing.T) {
 	_, err = client.Message(request)
 	if err == nil {
 		t.Fatal("Expected an error, got none")
+	}
+}
+
+func TestMessageIncompatibleModel(t *testing.T) {
+	// Create client
+	client, err := NewClient("fake-api-key")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Prepare a message request with streaming set to true
+	request := &MessageRequest{
+		Model:    ClaudeV2,
+		Messages: []MessagePartRequest{{Role: "user", Content: "Hello"}},
+	}
+
+	// Call the MessageStream method expecting an error
+	_, err = client.Message(request)
+
+	if err == nil {
+		t.Fatal("Expected an error for streaming not supported, got none")
+	}
+
+	expErr := fmt.Sprintf("model %s is not compatible with the message endpoint", request.Model)
+
+	if err.Error() != expErr {
+		t.Fatalf(
+			"Expected error %s, got %s",
+			expErr,
+			err.Error(),
+		)
 	}
 }
 

--- a/pkg/anthropic/models.go
+++ b/pkg/anthropic/models.go
@@ -60,3 +60,20 @@ const (
 	// An earlier version of ClaudeInstantV1.
 	ClaudeInstantV1_0 Model = "claude-instant-v1.0"
 )
+
+func (m Model) IsMessageStreamCompatible() bool {
+	switch m {
+	case Claude3Opus, Claude3Sonnet, ClaudeV2_1:
+		return true
+	}
+	return false
+}
+
+func (m Model) IsCompleteCompatible() bool {
+	switch m {
+	case ClaudeV2_1, ClaudeV2, ClaudeV1, ClaudeV1_100k, ClaudeInstantV1, ClaudeInstantV1_100k, ClaudeV1_3, ClaudeV1_3_100k, ClaudeV1_2, ClaudeV1_0, ClaudeInstantV1_1, ClaudeInstantV1_1_100k, ClaudeInstantV1_0:
+		return true
+	}
+
+	return false
+}

--- a/pkg/anthropic/models.go
+++ b/pkg/anthropic/models.go
@@ -61,7 +61,7 @@ const (
 	ClaudeInstantV1_0 Model = "claude-instant-v1.0"
 )
 
-func (m Model) IsMessageStreamCompatible() bool {
+func (m Model) IsMessageCompatible() bool {
 	switch m {
 	case Claude3Opus, Claude3Sonnet, ClaudeV2_1:
 		return true

--- a/pkg/anthropic/response.go
+++ b/pkg/anthropic/response.go
@@ -33,3 +33,21 @@ type MessageResponse struct {
 	Stop         string                `json:"stop"`
 	StopSequence string                `json:"stop_sequence"`
 }
+
+type MessageStreamResponse struct {
+	Type  string             `json:"type"`
+	Delta MessageStreamDelta `json:"delta"`
+	Usage MessageStreamUsage `json:"usage"`
+}
+
+type MessageStreamDelta struct {
+	Type         string `json:"type"`
+	Text         string `json:"text"`
+	StopReason   string `json:"stop_reason"`
+	StopSequence string `json:"stop_sequence"`
+}
+
+type MessageStreamUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}

--- a/pkg/anthropic/response.go
+++ b/pkg/anthropic/response.go
@@ -32,6 +32,12 @@ type MessageResponse struct {
 	StopReason   string                `json:"stop_reason"`
 	Stop         string                `json:"stop"`
 	StopSequence string                `json:"stop_sequence"`
+	Usage        MessageUsage          `json:"usage"`
+}
+
+type MessageUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
 }
 
 type MessageStreamResponse struct {

--- a/pkg/internal/examples/messages/stream/example.go
+++ b/pkg/internal/examples/messages/stream/example.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/madebywelch/anthropic-go/v2/pkg/anthropic"
+)
+
+func main() {
+	client, err := anthropic.NewClient("your-api-key")
+	if err != nil {
+		panic(err)
+	}
+
+	messages := []anthropic.MessagePartRequest{
+		{
+			Role:    "user",
+			Content: "Why is the sky blue?",
+		},
+	}
+
+	request := anthropic.NewMessageRequest(
+		messages,
+		anthropic.WithModel[anthropic.MessageRequest](anthropic.Claude3Opus),
+		anthropic.WithMaxTokens[anthropic.MessageRequest](1000),
+		anthropic.WithStream[anthropic.MessageRequest](true),
+	)
+
+	rCh, errCh := client.MessageStream(request)
+
+	final := strings.Builder{}
+	chunk := anthropic.MessageStreamResponse{}
+	done := false
+
+	for {
+		select {
+		case chunk = <-rCh:
+			final.WriteString(chunk.Delta.Text)
+			fmt.Print(chunk.Delta.Text)
+		case err := <-errCh:
+			fmt.Printf("\n\nError: %s\n\n", err)
+			done = true
+			break
+		}
+		if chunk.Type == "message_stop" || done {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	fmt.Println("-------------------FINAL RESULT----------------------")
+	fmt.Println(final.String())
+	fmt.Println("-----------------------------------------------------")
+}


### PR DESCRIPTION
Add compatibility checks for models & their ability to use the Completion or Message endpoints.

I also implemented message streaming for models claude-v2.1, claude3opus-20240229, claude3sonnet-20240229. I referenced the documentation here when setting up the different event types:
https://docs.anthropic.com/claude/reference/messages-streaming