### PR TITLE
Add ToolChoice Support

### DIFF
--- a/pkg/anthropic/options.go
+++ b/pkg/anthropic/options.go
@@ -54,6 +54,18 @@ func WithMetadata[T MessageRequest](metadata interface{}) GenericOption[T] {
 	}
 }
 
+func WithToolChoice[T MessageRequest](toolType, toolName string) GenericOption[T] {
+	return func(r *T) {
+		switch v := any(r).(type) {
+		case *MessageRequest:
+			v.ToolChoice = &ToolChoice{
+				Type: toolType,
+				Name: toolName,
+			}
+		}
+	}
+}
+
 func WithStreaming[T any](stream bool) GenericOption[T] {
 	return WithStream[T](stream)
 }

--- a/pkg/anthropic/request.go
+++ b/pkg/anthropic/request.go
@@ -94,6 +94,12 @@ func NewImageContentBlock(mediaType MediaType, base64Data string) ContentBlock {
 	}
 }
 
+// ToolChoice specifies the tool preferences for a message request.
+type ToolChoice struct {
+	Type string `json:"type"` // Type of tool choice: "tool", "any", or "auto".
+	Name string `json:"name"` // Name of the tool to be used (if type is "tool").
+}
+
 // MessageRequest is the request to the Anthropic API for a message request.
 type MessageRequest struct {
 	Model             Model                `json:"model"`
@@ -105,6 +111,7 @@ type MessageRequest struct {
 	StopSequences     []string             `json:"stop_sequences,omitempty"` // optional
 	Stream            bool                 `json:"stream,omitempty"`         // optional
 	Temperature       float64              `json:"temperature,omitempty"`    // optional
+	ToolChoice        *ToolChoice          `json:"tool_choice,omitempty"`    // optional
 	TopK              int                  `json:"top_k,omitempty"`          // optional
 	TopP              float64              `json:"top_p,omitempty"`          // optional
 }


### PR DESCRIPTION
This PR adds support for the `ToolChoice` field to specify tool preferences in message requests.

#### Usage

You can force Claude to use a specific tool by specifying the tool in the `tool_choice` field. For example, to explicitly tell Claude to use the `get_weather` tool, you can set `tool_choice` as follows:

```json
{
  "tool_choice": {"type": "tool", "name": "get_weather"}
}
```

This technique is useful for testing and debugging tool integrations or when you know that a tool should always be used, regardless of input.

#### ToolChoice Types

- **"tool"**: Use a specific tool.
- **"any"**: Allow any available tool.
- **"auto"**: Let the model decide whether or not to use a tool (default).

For instance, to let Claude decide, you can use:

```json
{
  "tool_choice": {"type": "auto"}
}
```

#### Note

When `tool_choice` is set to `any` or `tool`, the assistant message is prefilled to force a tool to be used. This means the model will not emit a chain-of-thought text content block before `tool_use` content blocks, even if explicitly asked to do so. Testing has shown that this does not reduce performance.

If you want to keep the chain-of-thought while still requesting the model to use a specific tool, use `{"type": "auto"}` for `tool_choice` and add explicit instructions in a user message. For example:

```json
{
  "prompt": "What's the weather like in London? Use the get_weather tool in your response."
}
```

For more details, please refer to the [Anthropic documentation](https://docs.anthropic.com/en/docs/tool-use#forcing-tool-use).

---

### Example Code

Here is an example demonstrating how to use the `ToolChoice` feature in a message request:

```go
package main

import (
	"fmt"

	"github.com/madebywelch/anthropic-go/v2/pkg/anthropic"
)

func main() {
	client, err := anthropic.NewClient("your-api-key")
	if err != nil {
		panic(err)
	}

	// Prepare a message request with ToolChoice
	request := anthropic.NewMessageRequest(
		[]anthropic.MessagePartRequest{{Role: "user", Content: []anthropic.ContentBlock{anthropic.NewTextContentBlock("Hello, world!")}}},
		anthropic.WithModel[anthropic.MessageRequest](anthropic.ClaudeV2_1),
		anthropic.WithMaxTokens,
		anthropic.WithToolChoice[anthropic.MessageRequest]("tool", "get_weather"),
	)

	// Call the Message method
	response, err := client.Message(request)
	if err != nil {
		panic(err)
	}

	fmt.Println(response.Content)
}
```