### PR TITLE
Add ToolResultContentBlock to Handle Tool Result Content

### DIFF
--- a/pkg/anthropic/request.go
+++ b/pkg/anthropic/request.go
@@ -94,6 +94,26 @@ func NewImageContentBlock(mediaType MediaType, base64Data string) ContentBlock {
 	}
 }
 
+// ToolResultContentBlock represents a block of tool result content.
+type ToolResultContentBlock struct {
+	Type      string      `json:"type"`
+	ToolUseID string      `json:"tool_use_id"`
+	Content   interface{} `json:"content"`
+	IsError   bool        `json:"is_error,omitempty"`
+}
+
+func (t ToolResultContentBlock) isContentBlock() {}
+
+// NewToolResultContentBlock creates a new tool result content block with the given parameters.
+func NewToolResultContentBlock(toolUseID string, content interface{}, isError bool) ContentBlock {
+	return ToolResultContentBlock{
+		Type:      "tool_result",
+		ToolUseID: toolUseID,
+		Content:   content,
+		IsError:   isError,
+	}
+}
+
 // ToolChoice specifies the tool preferences for a message request.
 type ToolChoice struct {
 	Type string `json:"type"` // Type of tool choice: "tool", "any", or "auto".

--- a/pkg/internal/integration_tests/message_integration_test.go
+++ b/pkg/internal/integration_tests/message_integration_test.go
@@ -58,6 +58,61 @@ func TestMessageWithToolsIntegration(t *testing.T) {
 	}
 }
 
+func TestMessageWithForcedToolIntegration(t *testing.T) {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		t.Skip("ANTHROPIC_API_KEY environment variable is not set, skipping integration test")
+	}
+
+	client, err := anthropic.NewClient(apiKey)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	request := &anthropic.MessageRequest{
+		Model:             anthropic.Claude3Opus,
+		MaxTokensToSample: 1024,
+		ToolChoice: &anthropic.ToolChoice{
+			Type: "tool",
+			Name: "get_weather",
+		},
+		Tools: []anthropic.Tool{
+			{
+				Name:        "get_weather",
+				Description: "Get the weather",
+				InputSchema: anthropic.InputSchema{
+					Type: "object",
+					Properties: map[string]anthropic.Property{
+						"city": {Type: "string", Description: "city to get the weather for"},
+						"unit": {Type: "string", Enum: []string{"celsius", "fahrenheit"}, Description: "temperature unit to return"}},
+					Required: []string{"city"},
+				},
+			},
+		},
+		Messages: []anthropic.MessagePartRequest{
+			{
+				Role: "user",
+				Content: []anthropic.ContentBlock{
+					anthropic.NewTextContentBlock("what's the weather in Charleston?"),
+				},
+			},
+		},
+	}
+
+	response, err := client.Message(request)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if response == nil || len(response.Content) == 0 {
+		t.Errorf("Expected a message response, got none or empty content")
+	}
+
+	if response.StopReason != "tool_use" {
+		t.Errorf("Expected stop reason 'tool_use', got %s", response.StopReason)
+	}
+}
+
 func TestMessageWithImageIntegration(t *testing.T) {
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
 	if apiKey == "" {


### PR DESCRIPTION
This PR introduces the `ToolResultContentBlock` to represent the content of tool results, enabling better integration and handling of tool responses.

#### Changes

1. **ToolResultContentBlock**:
    - Added `ToolResultContentBlock` to handle tool result content.
    - Fields include `Type`, `ToolUseID`, `Content`, and optional `IsError`.

2. **NewToolResultContentBlock Function**:
    - Added a helper function to create `ToolResultContentBlock` instances.

#### Usage

When you receive a tool use response, follow these steps:

1. Extract the `name`, `id`, and `input` from the `tool_use` block.
2. Run the actual tool in your codebase corresponding to that tool name, passing in the tool input.
3. Optionally, continue the conversation by sending a new message with the role of `user`, and a content block containing the `tool_result` type and the following information:
   - `tool_use_id`: The id of the tool use request this is a result for.
   - `content`: The result of the tool, as a string or list of nested content blocks.
   - `is_error` (optional): Set to true if the tool execution resulted in an error.

#### Example

Here’s an example of returning a successful tool result:

```json
{
  "role": "user",
  "content": [
    {
      "type": "tool_result",
      "tool_use_id": "toolu_01A09q90qw90lq917835lq9",
      "content": "15 degrees"
    }
  ]
}
```

For more details on tool use and tool result content blocks, please refer to the [Anthropic documentation](https://docs.anthropic.com/en/docs/tool-use#tool-use-and-tool-result-content-blocks).

#### Go Usage

Here’s how you can use the `ToolResultContentBlock` in the code:

```go
package main

import (
	"fmt"
	"os"

	"github.com/madebywelch/anthropic-go/v2/pkg/anthropic"
)

func main() {
	apiKey := os.Getenv("ANTHROPIC_API_KEY")
	if apiKey == "" {
		fmt.Println("ANTHROPIC_API_KEY environment variable is not set")
		return
	}

	client, err := anthropic.NewClient(apiKey)
	if err != nil {
		fmt.Printf("Unexpected error: %v\n", err)
		return
	}

	// Simulate tool result content
	toolResultContent := "15 degrees"
	toolUseID := "toolu_01A09q90qw90lq917835lq9"

	// Create a tool result content block
	toolResultBlock := anthropic.NewToolResultContentBlock(toolUseID, toolResultContent, false)

	// Create a new message request to send the tool result
	resultRequest := &anthropic.MessageRequest{
		Model:             anthropic.Claude3Opus,
		MaxTokensToSample: 1024,
		Messages: []anthropic.MessagePartRequest{
			{
				Role: "user",
				Content: []anthropic.ContentBlock{
					toolResultBlock,
				},
			},
		},
	}

	// Send the message request
	response, err := client.Message(resultRequest)
	if err != nil {
		fmt.Printf("Unexpected error: %v\n", err)
		return
	}

	if response == nil || len(response.Content) == 0 {
		fmt.Println("Expected a message response for tool result, got none or empty content")
		return
	}

	fmt.Println(response.Content)
}
```

This example demonstrates how to create and send a `ToolResultContentBlock` in a message request using the Anthropic Go client. The `main` function shows the complete flow from creating the tool result content block to sending the request and handling the response.
