### PR TITLE
Support more complex tool input schemas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,4 +21,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.30.1 // indirect
 	github.com/aws/smithy-go v1.20.3 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/invopop/jsonschema v0.12.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,3 +28,17 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.30.1 h1:+woJ607dllHJQtsnJLi52ycuqHMw
 github.com/aws/aws-sdk-go-v2/service/sts v1.30.1/go.mod h1:jiNR3JqT15Dm+QWq2SRgh0x0bCNSRP2L25+CqPNpJlQ=
 github.com/aws/smithy-go v1.20.3 h1:ryHwveWzPV5BIof6fyDvor6V3iUL7nTfiTKXHiW05nE=
 github.com/aws/smithy-go v1.20.3/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/invopop/jsonschema v0.12.0 h1:6ovsNSuvn9wEQVOyc72aycBMVQFKz7cPdMJn10CvzRI=
+github.com/invopop/jsonschema v0.12.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
+github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/anthropic/request.go
+++ b/pkg/anthropic/request.go
@@ -1,5 +1,7 @@
 package anthropic
 
+import "github.com/invopop/jsonschema"
+
 // CompletionRequest is the request to the Anthropic API for a completion.
 type CompletionRequest struct {
 	Prompt            string   `json:"prompt"`
@@ -116,8 +118,8 @@ func NewToolResultContentBlock(toolUseID string, content interface{}, isError bo
 
 // ToolChoice specifies the tool preferences for a message request.
 type ToolChoice struct {
-	Type string `json:"type"` // Type of tool choice: "tool", "any", or "auto".
-	Name string `json:"name"` // Name of the tool to be used (if type is "tool").
+	Type string `json:"type"` 			// Type of tool choice: "tool", "any", or "auto".
+	Name string `json:"name,omitempty"` // Name of the tool to be used (if type is "tool").
 }
 
 // MessageRequest is the request to the Anthropic API for a message request.
@@ -136,22 +138,14 @@ type MessageRequest struct {
 	TopP              float64              `json:"top_p,omitempty"`          // optional
 }
 
-type Property struct {
-	Type        string   `json:"type"`
-	Enum        []string `json:"enum,omitempty"`
-	Description string   `json:"description"`
-}
-
-type InputSchema struct {
-	Type       string              `json:"type"`
-	Properties map[string]Property `json:"properties"`
-	Required   []string            `json:"required"`
-}
-
 type Tool struct {
-	Name        string      `json:"name"`
-	Description string      `json:"description"`
-	InputSchema InputSchema `json:"input_schema"`
+	Name        string             `json:"name"`
+	Description string             `json:"description"`
+	InputSchema *jsonschema.Schema `json:"input_schema"`
+}
+
+func GenerateInputSchema(input interface{}) *jsonschema.Schema {
+	return (&jsonschema.Reflector{ExpandedStruct: true}).Reflect(input)
 }
 
 // CountImageContent counts the number of ImageContentBlock in the MessageRequest.

--- a/pkg/anthropic/request.go
+++ b/pkg/anthropic/request.go
@@ -118,7 +118,7 @@ func NewToolResultContentBlock(toolUseID string, content interface{}, isError bo
 
 // ToolChoice specifies the tool preferences for a message request.
 type ToolChoice struct {
-	Type string `json:"type"` 			// Type of tool choice: "tool", "any", or "auto".
+	Type string `json:"type"`           // Type of tool choice: "tool", "any", or "auto".
 	Name string `json:"name,omitempty"` // Name of the tool to be used (if type is "tool").
 }
 

--- a/pkg/internal/examples/messages/tools/example.go
+++ b/pkg/internal/examples/messages/tools/example.go
@@ -7,6 +7,11 @@ import (
 	"github.com/madebywelch/anthropic-go/v3/pkg/anthropic/client/native"
 )
 
+type WeatherRequest struct {
+	City string `json:"city" jsonschema:"required,description=city to get the weather for"`
+	Unit string `json:"unit" jsonschema:"enum=celsius,enum=fahrenheit,description=temperature unit to return"`
+}
+
 func main() {
 	ctx := context.Background()
 	client, err := native.MakeClient(native.Config{
@@ -24,13 +29,7 @@ func main() {
 			{
 				Name:        "get_weather",
 				Description: "Get the weather",
-				InputSchema: anthropic.InputSchema{
-					Type: "object",
-					Properties: map[string]anthropic.Property{
-						"city": {Type: "string", Description: "city to get the weather for"},
-						"unit": {Type: "string", Enum: []string{"celsius", "fahrenheit"}, Description: "temperature unit to return"}},
-					Required: []string{"city"},
-				},
+				InputSchema: anthropic.GenerateInputSchema(&WeatherRequest{}),
 			},
 		},
 		Messages: []anthropic.MessagePartRequest{


### PR DESCRIPTION
The current InputSchema struct is not capable of representing nested fields. This uses https://github.com/invopop/jsonschema to allow for full json schemas to be generated.

If we wanted to be less opinionated and reduce dependencies, we could follow the lead of go-openai and just type `InputSchema` as `interface{}` instead, and json.Marshal whatever is provided