### PR TITLE
Add sonnet 3.5 20241022 w/ bedrock support

### DIFF
--- a/pkg/anthropic/client/bedrock/client.go
+++ b/pkg/anthropic/client/bedrock/client.go
@@ -16,11 +16,12 @@ import (
 const (
 	AnthropicVersion = "bedrock-2023-05-31"
 
-	BedrockModelClaude35Sonnet = "anthropic.claude-3-5-sonnet-20240620-v1:0"
-	BedrockModelClaude3Opus    = "anthropic.claude-3-opus-20240229-v1:0"
-	BedrockModelClaude3Sonnet  = "anthropic.claude-3-sonnet-20240229-v1:0"
-	BedrockModelClaude3Haiku   = "anthropic.claude-3-haiku-20240307-v1:0"
-	BedrockModelClaudeV2_1     = "anthropic.claude-v2:1"
+	BedrockModelClaude35Sonnet          = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+	BedrockModelClaude35Sonnet_20240620 = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+	BedrockModelClaude3Opus             = "anthropic.claude-3-opus-20240229-v1:0"
+	BedrockModelClaude3Sonnet           = "anthropic.claude-3-sonnet-20240229-v1:0"
+	BedrockModelClaude3Haiku            = "anthropic.claude-3-haiku-20240307-v1:0"
+	BedrockModelClaudeV2_1              = "anthropic.claude-v2:1"
 
 	// Cross-region top-level region code
 	CRUS = "us"
@@ -91,6 +92,8 @@ func (c *Client) adaptModelForMessage(model anthropic.Model) (string, error) {
 	switch model {
 	case anthropic.Claude35Sonnet:
 		adaptedModel = BedrockModelClaude35Sonnet
+	case anthropic.Claude35Sonnet_20240620:
+		adaptedModel = BedrockModelClaude35Sonnet_20240620
 	case anthropic.Claude3Opus:
 		adaptedModel = BedrockModelClaude3Opus
 	case anthropic.Claude3Sonnet:

--- a/pkg/anthropic/models.go
+++ b/pkg/anthropic/models.go
@@ -6,7 +6,10 @@ type Model string
 // https://docs.anthropic.com/claude/docs/models-overview
 const (
 	// Highest level of intelligence and capability
-	Claude35Sonnet Model = "claude-3-5-sonnet-20240620"
+	Claude35Sonnet Model = "claude-3-5-sonnet-latest"
+
+	// Former highest level of intelligence and capability
+	Claude35Sonnet_20240620 Model = "claude-3-5-sonnet-20240620"
 
 	// Most powerful model for highly complex tasks.
 	Claude3Opus Model = "claude-3-opus-20240229"
@@ -66,7 +69,7 @@ const (
 
 func (m Model) IsImageCompatible() bool {
 	switch m {
-	case Claude3Haiku, Claude3Opus, Claude3Sonnet, Claude35Sonnet:
+	case Claude3Haiku, Claude3Opus, Claude3Sonnet, Claude35Sonnet, Claude35Sonnet_20240620:
 		return true
 	}
 	return false
@@ -74,7 +77,7 @@ func (m Model) IsImageCompatible() bool {
 
 func (m Model) IsMessageCompatible() bool {
 	switch m {
-	case Claude3Opus, Claude3Sonnet, Claude3Haiku, ClaudeV2_1, Claude35Sonnet:
+	case Claude3Opus, Claude3Sonnet, Claude3Haiku, ClaudeV2_1, Claude35Sonnet, Claude35Sonnet_20240620:
 		return true
 	}
 	return false


### PR DESCRIPTION
@madebywelch There's another PR up doing something similar but the approach requires a conscious switch to the newer sonnet model, whereas this PR will keep any usage of claude-sonnet-3.5 pegged to the latest and any desire to use the previous model becomes the conscious decision.

I also added support for the bedrock client.